### PR TITLE
Use install:addon syntax in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ ember-slide-show is a simple Ember CLI addon that can be used to add a slideshow
 ## Installing
 
 ```
-ember install:npm ember-slide-show
-ember g ember-slide-show #apply the blueprint
+ember install:addon ember-slide-show
 ```
 
 ## Using in your app


### PR DESCRIPTION
The command `ember install:addon` combines the npm installation
and generation steps, simplifying installation of the addon
to a single command.
